### PR TITLE
Fix shift del caching

### DIFF
--- a/src/org/denis/AbstractCopyPasteSyntaxAwareProcessor.java
+++ b/src/org/denis/AbstractCopyPasteSyntaxAwareProcessor.java
@@ -41,7 +41,7 @@ public abstract class AbstractCopyPasteSyntaxAwareProcessor<T extends TextBlockT
   private static final Logger LOG = Logger.getInstance("#" + AbstractCopyPasteSyntaxAwareProcessor.class.getName());
   
   private static ThreadLocal<Pair<Long, SyntaxInfo>> CACHED = new ThreadLocal<Pair<Long, SyntaxInfo>>();
-  private static final long CACHE_TTL_MS = 0;
+  private static final long CACHE_TTL_MS = 100;
 
   @SuppressWarnings("unchecked")
   @Nullable

--- a/src/org/denis/AbstractCopyPasteSyntaxAwareProcessor.java
+++ b/src/org/denis/AbstractCopyPasteSyntaxAwareProcessor.java
@@ -41,7 +41,7 @@ public abstract class AbstractCopyPasteSyntaxAwareProcessor<T extends TextBlockT
   private static final Logger LOG = Logger.getInstance("#" + AbstractCopyPasteSyntaxAwareProcessor.class.getName());
   
   private static ThreadLocal<Pair<Long, SyntaxInfo>> CACHED = new ThreadLocal<Pair<Long, SyntaxInfo>>();
-  private static final long CACHE_TTL_MS = 100;
+  private static final long CACHE_TTL_MS = 0;
 
   @SuppressWarnings("unchecked")
   @Nullable
@@ -52,9 +52,12 @@ public abstract class AbstractCopyPasteSyntaxAwareProcessor<T extends TextBlockT
       return null;
     }
 
-    SyntaxInfo cached = getCached();
-    if (cached != null) {
-      return build(cached);
+    //Use cache only for multi-line selections only. Because single-line cut can be really fast with shift+del.
+    if (endOffsets.length > 1) {
+      SyntaxInfo cached = getCached();
+      if (cached != null) {
+        return build(cached);
+      }
     }
 
     SelectionModel selectionModel = editor.getSelectionModel();
@@ -122,7 +125,9 @@ public abstract class AbstractCopyPasteSyntaxAwareProcessor<T extends TextBlockT
     }
     SyntaxInfo syntaxInfo = context.finish();
     logSyntaxInfo(syntaxInfo);
-    CACHED.set(Pair.create(System.currentTimeMillis(), syntaxInfo));
+    if (endOffsets.length > 1) {
+      CACHED.set(Pair.create(System.currentTimeMillis(), syntaxInfo));
+    }
     return build(syntaxInfo);
   }
 


### PR DESCRIPTION
I disabled single line SyntaxInfo cache because you can cut lines really fast when pressing shift+del. In that case you get previous line SyntaxInfo from cache, it might cause SOOBE. This should fix https://github.com/denis-zhdanov/intellij-plugin-copy-on-steroids/issues/10.
